### PR TITLE
Explicitly `require` additional modules from `multiple-cursors`.

### DIFF
--- a/mc-mark-extras.el
+++ b/mc-mark-extras.el
@@ -47,6 +47,7 @@
 
 (require 'cl)
 (require 'multiple-cursors-core)
+(require 'mc-mark-more)
 
 (defun mc/mark-sexps (num-sexps direction)
   (dotimes (i (if (= num-sexps 0) 1 num-sexps))

--- a/mc-remove.el
+++ b/mc-remove.el
@@ -46,6 +46,7 @@
 
 (require 'cl)
 (require 'multiple-cursors-core)
+(require 'mc-cycle-cursors)
 
 ;;;###autoload
 (defun mc/remove-current-cursor ()


### PR DESCRIPTION
In my config, I have
``` emacs-lisp
(use-package multiple-cursors
      :defer t
      :bind ([...]))

(use-package mc-extras
      :defer t
      :bind (("C-, M-C-f" . mc/mark-next-sexps)
             ("C-, M-C-b" . mc/mark-previous-sexps)
             ("C-, C-k"   . mc/remove-cursors-at-eol)
             [...]))
```

I have no problems with most `mc-extras` functions out of the box, but the three I've listed here depend on functions from `multiple-cursors` that exist outside of `multiple-cursors-core`. If loading of `multiple-cursors` is deferred, these dependency functions don't get loaded in time.

`mc/mark-sexps` in `mc-mark-extras.el` invokes `mc/furthest-cursor-after(before)-point`, defined in `mc-mark-more`; `mc/next-fake-cursor-after-point` in `mc-cycle-cursors.el` invokes `mc/next-fake-cursor-after-point`, defined in `mc-cycle-cursors`.